### PR TITLE
Remove duplicate storage function definitions

### DIFF
--- a/script.js
+++ b/script.js
@@ -235,14 +235,6 @@ document.addEventListener("DOMContentLoaded", (() => {
     return window.innerWidth <= 768;
   }
 
-  // （重複定義的 ce 與 ie，保持一致）
-  function ce(e, t) {
-    localStorage.setItem(e, t)
-  }
-  function ie(e) {
-    return localStorage.getItem(e)
-  }
-
   Z.textContent = se;
   G.textContent = de;
   "speechSynthesis" in window


### PR DESCRIPTION
## Summary
- Remove redundant `ce` and `ie` helper definitions from the bottom of `script.js`.
- Keep the original definitions at the top for localStorage access.

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a44a00f3848332aaafebdb2af9abe5