### PR TITLE
Ensure restart uses selected category size

### DIFF
--- a/script.js
+++ b/script.js
@@ -381,7 +381,7 @@ document.addEventListener("DOMContentLoaded", (() => {
     P.textContent = "打字速度: 0 WPM";
     W.textContent = "打字速度: 0 WPM";
     V.classList.add("hidden");
-    ne ? ae(null, ne) : ae(parseInt(f.value), null);
+    ne ? ae(null, ne) : ae(K[R].length, null);
   });
 
   r.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- Use full category length instead of manual word count when restarting

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a44a035fe8833294c0c6eaee4ec682