### PR TITLE
Handle HTTP errors when loading word list

### DIFF
--- a/script.js
+++ b/script.js
@@ -250,7 +250,10 @@ document.addEventListener("DOMContentLoaded", (() => {
     : alert("抱歉，您的瀏覽器不支援語音合成功能。");
 
   fetch("words.json")
-    .then((e) => e.json())
+    .then((e) => {
+      if (!e.ok) throw new Error(`HTTP error! status: ${e.status}`);
+      return e.json();
+    })
     .then((n) => {
       K = n;
       O = Object.keys(n);


### PR DESCRIPTION
## Summary
- Validate fetch response for `words.json` and throw an error if the request fails before parsing

## Testing
- `node --check script.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a44a0658f483328e43661bff6de16a